### PR TITLE
(in-tree work) Remove enum Versions.Major, replacing all usages with Semver4j

### DIFF
--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -56,6 +56,7 @@
         <resolver:remoterepos id="all">
             <remoterepo id="resolver-central" url="${artifact.remoteRepository.central}"/>
             <remoterepo id="resolver-apache" url="${artifact.remoteRepository.apache}"/>
+            <remoterepo id="resolver-apache-snapshots" url="${artifact.remoteRepository.apache-snaphot}" snapshots="true"/>
         </resolver:remoterepos>
 
         <macrodef name="resolve">

--- a/build.properties.default
+++ b/build.properties.default
@@ -1,4 +1,5 @@
 # Maven2 Repository Locations (you can override these in "build.properties" to point to a local proxy, e.g. Nexus)
-artifact.remoteRepository.central:     https://repo1.maven.org/maven2
-artifact.remoteRepository.apache:      https://repo.maven.apache.org/maven2
+artifact.remoteRepository.central:              https://repo1.maven.org/maven2
+artifact.remoteRepository.apache:               https://repo.maven.apache.org/maven2
+artifact.remoteRepository.apache-snaphot:       https://repository.apache.org/content/groups/snapshots/
 

--- a/build.xml
+++ b/build.xml
@@ -529,7 +529,7 @@
           <dependency groupId="org.mockito" artifactId="mockito-core" version="3.2.4" scope="test"/>
           <dependency groupId="org.quicktheories" artifactId="quicktheories" version="0.26" scope="test"/>
           <dependency groupId="com.google.code.java-allocation-instrumenter" artifactId="java-allocation-instrumenter" version="${allocation-instrumenter.version}" />
-          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.8" scope="test"/>
+          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.8-SNAPSHOT" scope="test"/>
           <dependency groupId="org.reflections" artifactId="reflections" version="0.9.12" />
           <dependency groupId="org.apache.hadoop" artifactId="hadoop-core" version="1.0.3" scope="provided">
             <exclusion groupId="org.mortbay.jetty" artifactId="servlet-api"/>

--- a/build.xml
+++ b/build.xml
@@ -529,7 +529,7 @@
           <dependency groupId="org.mockito" artifactId="mockito-core" version="3.2.4" scope="test"/>
           <dependency groupId="org.quicktheories" artifactId="quicktheories" version="0.26" scope="test"/>
           <dependency groupId="com.google.code.java-allocation-instrumenter" artifactId="java-allocation-instrumenter" version="${allocation-instrumenter.version}" />
-          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.7" scope="test"/>
+          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.8" scope="test"/>
           <dependency groupId="org.reflections" artifactId="reflections" version="0.9.12" />
           <dependency groupId="org.apache.hadoop" artifactId="hadoop-core" version="1.0.3" scope="provided">
             <exclusion groupId="org.mortbay.jetty" artifactId="servlet-api"/>

--- a/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
@@ -216,7 +216,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
             if (instanceInitializer != null)
                 instanceInitializer.accept(classLoader, config.num());
             return Instance.transferAdhoc((SerializableBiFunction<IInstanceConfig, ClassLoader, Instance>)Instance::new, classLoader)
-                                        .apply(config.forVersion(version.major), classLoader);
+                                        .apply(config.forVersion(version.version), classLoader);
         }
 
         public IInstanceConfig config()

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -286,13 +286,13 @@ public class InstanceConfig implements IInstanceConfig
 
     public InstanceConfig forVersion(Versions.Major major)
     {
-        switch (major)
-        {
-            case v4: return this;
-            default: return new InstanceConfig(this)
+        // Versions before 4.0 need to set 'seed_provider' without specifying the port
+        if (Versions.Major.v40.compareTo(major) <= 0)
+            return this;
+        else
+            return new InstanceConfig(this)
                             .set("seed_provider", new ParameterizedClass(SimpleSeedProvider.class.getName(),
                                                                          Collections.singletonMap("seeds", "127.0.0.1")));
-        }
     }
 
     public String toString()

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -19,10 +19,8 @@
 package org.apache.cassandra.distributed.impl;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
@@ -30,15 +28,15 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
 
+import com.vdurmont.semver4j.Semver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.YamlConfigurationLoader;
 import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.distributed.shared.Shared;
-import org.apache.cassandra.distributed.shared.Versions;
+import org.apache.cassandra.distributed.upgrade.UpgradeTestBase;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.SimpleSeedProvider;
 
@@ -284,10 +282,10 @@ public class InstanceConfig implements IInstanceConfig
         return datadirs;
     }
 
-    public InstanceConfig forVersion(Versions.Major major)
+    public InstanceConfig forVersion(Semver version)
     {
         // Versions before 4.0 need to set 'seed_provider' without specifying the port
-        if (Versions.Major.v40.compareTo(major) <= 0)
+        if (UpgradeTestBase.v40.compareTo(version) < 0)
             return this;
         else
             return new InstanceConfig(this)

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorage3to4UpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorage3to4UpgradeTest.java
@@ -35,7 +35,7 @@ public class CompactStorage3to4UpgradeTest extends UpgradeTestBase
     public void testNullClusteringValues() throws Throwable
     {
         new TestCase().nodes(1)
-                      .upgrade(Versions.Major.v30, Versions.Major.v4)
+                      .upgradesFrom(Versions.Major.v30)
                       .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL))
                       .setup(cluster -> {
                           String create = "CREATE TABLE %s.%s(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) " +

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorage3to4UpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorage3to4UpgradeTest.java
@@ -35,7 +35,7 @@ public class CompactStorage3to4UpgradeTest extends UpgradeTestBase
     public void testNullClusteringValues() throws Throwable
     {
         new TestCase().nodes(1)
-                      .upgradesFrom(Versions.Major.v30)
+                      .upgradesFrom(v30)
                       .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL))
                       .setup(cluster -> {
                           String create = "CREATE TABLE %s.%s(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) " +

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorageUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorageUpgradeTest.java
@@ -37,7 +37,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
         })
@@ -68,7 +68,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
             for (int i = 1; i < 10; i++)
@@ -94,7 +94,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck1 int, ck2 int, v int, PRIMARY KEY (pk, ck1, ck2)) WITH COMPACT STORAGE");
         })
@@ -113,7 +113,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
         })
@@ -145,7 +145,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(1, 2)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .withConfig(config -> config.with(GOSSIP, NETWORK))
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorageUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStorageUpgradeTest.java
@@ -37,7 +37,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
         })
@@ -68,7 +68,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
             for (int i = 1; i < 10; i++)
@@ -94,7 +94,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck1 int, ck2 int, v int, PRIMARY KEY (pk, ck1, ck2)) WITH COMPACT STORAGE");
         })
@@ -113,7 +113,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(2)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");
         })
@@ -145,7 +145,7 @@ public class CompactStorageUpgradeTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(1, 2)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .withConfig(config -> config.with(GOSSIP, NETWORK))
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
@@ -37,7 +37,7 @@ public class GroupByTest extends UpgradeTestBase
         // CASSANDRA-16582: group-by across mixed version cluster would fail with ArrayIndexOutOfBoundException
         new UpgradeTestBase.TestCase()
         .nodes(2)
-        .upgrade(Versions.Major.v3X, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v3X)
         .nodesToUpgrade(1)
         .withConfig(config -> config.with(GOSSIP, NETWORK))
         .setup(cluster -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
@@ -37,7 +37,7 @@ public class GroupByTest extends UpgradeTestBase
         // CASSANDRA-16582: group-by across mixed version cluster would fail with ArrayIndexOutOfBoundException
         new UpgradeTestBase.TestCase()
         .nodes(2)
-        .upgradesFrom(Versions.Major.v3X)
+        .upgradesFrom(v3X)
         .nodesToUpgrade(1)
         .withConfig(config -> config.with(GOSSIP, NETWORK))
         .setup(cluster -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static java.lang.String.format;
 
+
 public class MixedModeAvailabilityTestBase extends UpgradeTestBase
 {
     private static final int NUM_NODES = 3;
@@ -49,7 +50,12 @@ public class MixedModeAvailabilityTestBase extends UpgradeTestBase
                                                               new Tester(ALL, ONE));
 
 
-    protected static void testAvailability(Versions.Major initial, Versions.Major... upgrade) throws Throwable
+    protected static void testAvailability(Versions.Major initial) throws Throwable
+    {
+        testAvailability(initial, UpgradeTestBase.CURRENT);
+    }
+
+    protected static void testAvailability(Versions.Major initial, Versions.Major upgrade) throws Throwable
     {
         testAvailability(true, initial, upgrade);
         testAvailability(false, initial, upgrade);
@@ -57,12 +63,12 @@ public class MixedModeAvailabilityTestBase extends UpgradeTestBase
 
     private static void testAvailability(boolean upgradedCoordinator,
                                          Versions.Major initial,
-                                         Versions.Major... upgrade) throws Throwable
+                                         Versions.Major upgrade) throws Throwable
     {
         new TestCase()
         .nodes(NUM_NODES)
         .nodesToUpgrade(upgradedCoordinator ? 1 : 2)
-        .upgrade(initial, upgrade)
+        .upgrades(initial, upgrade)
         .withConfig(config -> config.set("read_request_timeout_in_ms", SECONDS.toMillis(2))
                                     .set("write_request_timeout_in_ms", SECONDS.toMillis(2)))
         .setup(c -> c.schemaChange(withKeyspace("CREATE TABLE %s.t (k uuid, c int, v int, PRIMARY KEY (k, c))")))

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
@@ -22,9 +22,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import com.vdurmont.semver4j.Semver;
+
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.ICoordinator;
-import org.apache.cassandra.distributed.shared.Versions;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.net.Verb;
@@ -50,20 +51,20 @@ public class MixedModeAvailabilityTestBase extends UpgradeTestBase
                                                               new Tester(ALL, ONE));
 
 
-    protected static void testAvailability(Versions.Major initial) throws Throwable
+    protected static void testAvailability(Semver initial) throws Throwable
     {
         testAvailability(initial, UpgradeTestBase.CURRENT);
     }
 
-    protected static void testAvailability(Versions.Major initial, Versions.Major upgrade) throws Throwable
+    protected static void testAvailability(Semver initial, Semver upgrade) throws Throwable
     {
         testAvailability(true, initial, upgrade);
         testAvailability(false, initial, upgrade);
     }
 
     private static void testAvailability(boolean upgradedCoordinator,
-                                         Versions.Major initial,
-                                         Versions.Major upgrade) throws Throwable
+                                         Semver initial,
+                                         Semver upgrade) throws Throwable
     {
         new TestCase()
         .nodes(NUM_NODES)

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV22Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV22Test.java
@@ -30,12 +30,12 @@ public class MixedModeAvailabilityV22Test extends MixedModeAvailabilityTestBase
     @Test
     public void testAvailabilityV22ToV30() throws Throwable
     {
-        testAvailability(Versions.Major.v22, Versions.Major.v30);
+        testAvailability(v22, v30);
     }
 
     @Test
     public void testAvailabilityV22ToV3X() throws Throwable
     {
-        testAvailability(Versions.Major.v22, Versions.Major.v3X);
+        testAvailability(v22, v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV30Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV30Test.java
@@ -28,14 +28,8 @@ import org.apache.cassandra.distributed.shared.Versions;
 public class MixedModeAvailabilityV30Test extends MixedModeAvailabilityTestBase
 {
     @Test
-    public void testAvailabilityV30ToV3X() throws Throwable
+    public void testAvailability() throws Throwable
     {
-        testAvailability(Versions.Major.v30, Versions.Major.v3X);
-    }
-
-    @Test
-    public void testAvailabilityV30ToV4() throws Throwable
-    {
-        testAvailability(Versions.Major.v30, Versions.Major.v4);
+        testAvailability(Versions.Major.v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV30Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV30Test.java
@@ -30,6 +30,6 @@ public class MixedModeAvailabilityV30Test extends MixedModeAvailabilityTestBase
     @Test
     public void testAvailability() throws Throwable
     {
-        testAvailability(Versions.Major.v30);
+        testAvailability(v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV3XTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV3XTest.java
@@ -28,8 +28,8 @@ import org.apache.cassandra.distributed.shared.Versions;
 public class MixedModeAvailabilityV3XTest extends MixedModeAvailabilityTestBase
 {
     @Test
-    public void testAvailabilityV3XToV4() throws Throwable
+    public void testAvailability() throws Throwable
     {
-        testAvailability(Versions.Major.v3X, Versions.Major.v4);
+        testAvailability(Versions.Major.v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV3XTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityV3XTest.java
@@ -30,6 +30,6 @@ public class MixedModeAvailabilityV3XTest extends MixedModeAvailabilityTestBase
     @Test
     public void testAvailability() throws Throwable
     {
-        testAvailability(Versions.Major.v3X);
+        testAvailability(v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeBatchTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeBatchTestBase.java
@@ -42,6 +42,11 @@ public class MixedModeBatchTestBase extends UpgradeTestBase
 {
     private static final int KEYS_PER_BATCH = 10;
 
+    protected void testSimpleStrategy(Versions.Major from, boolean isLogged) throws Throwable
+    {
+        testSimpleStrategy(from, UpgradeTestBase.CURRENT, isLogged);
+    }
+
     protected void testSimpleStrategy(Versions.Major from, Versions.Major to, boolean isLogged) throws Throwable
     {
         String insert = "INSERT INTO test_simple.names (key, name) VALUES (%d, '%s')";
@@ -50,7 +55,7 @@ public class MixedModeBatchTestBase extends UpgradeTestBase
         new TestCase()
         .nodes(3)
         .nodesToUpgrade(1, 2)
-        .upgrade(from, to)
+        .upgrades(from, to)
         .setup(cluster -> {
             cluster.schemaChange("CREATE KEYSPACE test_simple WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};");
             cluster.schemaChange("CREATE TABLE test_simple.names (key int PRIMARY KEY, name text)");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeBatchTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeBatchTestBase.java
@@ -21,10 +21,11 @@ package org.apache.cassandra.distributed.upgrade;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.vdurmont.semver4j.Semver;
+
 import org.apache.cassandra.distributed.UpgradeableCluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IMessageFilters;
-import org.apache.cassandra.distributed.shared.Versions;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 
@@ -42,12 +43,12 @@ public class MixedModeBatchTestBase extends UpgradeTestBase
 {
     private static final int KEYS_PER_BATCH = 10;
 
-    protected void testSimpleStrategy(Versions.Major from, boolean isLogged) throws Throwable
+    protected void testSimpleStrategy(Semver from, boolean isLogged) throws Throwable
     {
         testSimpleStrategy(from, UpgradeTestBase.CURRENT, isLogged);
     }
 
-    protected void testSimpleStrategy(Versions.Major from, Versions.Major to, boolean isLogged) throws Throwable
+    protected void testSimpleStrategy(Semver from, Semver to, boolean isLogged) throws Throwable
     {
         String insert = "INSERT INTO test_simple.names (key, name) VALUES (%d, '%s')";
         String select = "SELECT * FROM test_simple.names WHERE key = ?";

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTestBase.java
@@ -39,7 +39,12 @@ import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
 public class MixedModeConsistencyTestBase extends UpgradeTestBase
 {
-    protected static void testConsistency(Versions.Major initial, Versions.Major... upgrade) throws Throwable
+    protected static void testConsistency(Versions.Major initial) throws Throwable
+    {
+        testConsistency(initial, UpgradeTestBase.CURRENT);
+    }
+
+    protected static void testConsistency(Versions.Major initial, Versions.Major upgrade) throws Throwable
     {
         List<Tester> testers = new ArrayList<>();
         testers.addAll(Tester.create(1, ALL));
@@ -49,7 +54,7 @@ public class MixedModeConsistencyTestBase extends UpgradeTestBase
         new TestCase()
         .nodes(3)
         .nodesToUpgrade(1)
-        .upgrade(initial, upgrade)
+        .upgrades(initial, upgrade)
         .withConfig(config -> config.set("read_request_timeout_in_ms", SECONDS.toMillis(30))
                                     .set("write_request_timeout_in_ms", SECONDS.toMillis(30)))
         .setup(cluster -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTestBase.java
@@ -24,10 +24,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vdurmont.semver4j.Semver;
+
 import org.apache.cassandra.distributed.UpgradeableCluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IUpgradeableInstance;
-import org.apache.cassandra.distributed.shared.Versions;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -39,12 +40,12 @@ import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
 public class MixedModeConsistencyTestBase extends UpgradeTestBase
 {
-    protected static void testConsistency(Versions.Major initial) throws Throwable
+    protected static void testConsistency(Semver initial) throws Throwable
     {
         testConsistency(initial, UpgradeTestBase.CURRENT);
     }
 
-    protected static void testConsistency(Versions.Major initial, Versions.Major upgrade) throws Throwable
+    protected static void testConsistency(Semver initial, Semver upgrade) throws Throwable
     {
         List<Tester> testers = new ArrayList<>();
         testers.addAll(Tester.create(1, ALL));

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV22Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV22Test.java
@@ -30,12 +30,12 @@ public class MixedModeConsistencyV22Test extends MixedModeConsistencyTestBase
     @Test
     public void testConsistencyV22ToV30() throws Throwable
     {
-        testConsistency(Versions.Major.v22, Versions.Major.v30);
+        testConsistency(v22, v30);
     }
 
     @Test
     public void testConsistencyV22ToV3X() throws Throwable
     {
-        testConsistency(Versions.Major.v22, Versions.Major.v3X);
+        testConsistency(v22, v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV30Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV30Test.java
@@ -28,14 +28,8 @@ import org.apache.cassandra.distributed.shared.Versions;
 public class MixedModeConsistencyV30Test extends MixedModeConsistencyTestBase
 {
     @Test
-    public void testConsistencyV30ToV3X() throws Throwable
+    public void testConsistency() throws Throwable
     {
-        testConsistency(Versions.Major.v30, Versions.Major.v3X);
-    }
-
-    @Test
-    public void testConsistencyV30ToV4() throws Throwable
-    {
-        testConsistency(Versions.Major.v30, Versions.Major.v4);
+        testConsistency(Versions.Major.v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV30Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV30Test.java
@@ -30,6 +30,6 @@ public class MixedModeConsistencyV30Test extends MixedModeConsistencyTestBase
     @Test
     public void testConsistency() throws Throwable
     {
-        testConsistency(Versions.Major.v30);
+        testConsistency(v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV3XTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV3XTest.java
@@ -28,8 +28,8 @@ import org.apache.cassandra.distributed.shared.Versions;
 public class MixedModeConsistencyV3XTest extends MixedModeConsistencyTestBase
 {
     @Test
-    public void testConsistencyV3XToV4() throws Throwable
+    public void testConsistency() throws Throwable
     {
-        testConsistency(Versions.Major.v3X, Versions.Major.v4);
+        testConsistency(Versions.Major.v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV3XTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyV3XTest.java
@@ -30,6 +30,6 @@ public class MixedModeConsistencyV3XTest extends MixedModeConsistencyTestBase
     @Test
     public void testConsistency() throws Throwable
     {
-        testConsistency(Versions.Major.v3X);
+        testConsistency(v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2LoggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2LoggedBatchTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom2LoggedBatchTest extends MixedModeBatchTestBase
     @Test
     public void testSimpleStrategy22to30() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v30, true);
+        testSimpleStrategy(v22, v30, true);
     }
 
     @Test
     public void testSimpleStrategy22to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v3X, true);
+        testSimpleStrategy(v22, v3X, true);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2ReplicationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2ReplicationTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom2ReplicationTest extends MixedModeReplicationTestBase
     @Test
     public void testSimpleStrategy22to30() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v30);
+        testSimpleStrategy(v22, v30);
     }
 
     @Test
     public void testSimpleStrategy22to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v3X);
+        testSimpleStrategy(v22, v3X);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2UnloggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom2UnloggedBatchTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom2UnloggedBatchTest extends MixedModeBatchTestBase
     @Test
     public void testSimpleStrategy22to30() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v30, false);
+        testSimpleStrategy(v22, v30, false);
     }
 
     @Test
     public void testSimpleStrategy22to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v22, Versions.Major.v3X, false);
+        testSimpleStrategy(v22, v3X, false);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3LoggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3LoggedBatchTest.java
@@ -31,14 +31,8 @@ public class MixedModeFrom3LoggedBatchTest extends MixedModeBatchTestBase
     }
 
     @Test
-    public void testSimpleStrategy30to4() throws Throwable
+    public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v4, true);
-    }
-
-    @Test
-    public void testSimpleStrategy3Xto4() throws Throwable
-    {
-        testSimpleStrategy(Versions.Major.v3X, Versions.Major.v4, true);
+        testSimpleStrategy(Versions.Major.v30, true);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3LoggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3LoggedBatchTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom3LoggedBatchTest extends MixedModeBatchTestBase
     @Test
     public void testSimpleStrategy30to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v3X, true);
+        testSimpleStrategy(v30, v3X, true);
     }
 
     @Test
     public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, true);
+        testSimpleStrategy(v30, true);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3ReplicationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3ReplicationTest.java
@@ -31,14 +31,8 @@ public class MixedModeFrom3ReplicationTest extends MixedModeReplicationTestBase
     }
 
     @Test
-    public void testSimpleStrategy30to4() throws Throwable
+    public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v4);
-    }
-
-    @Test
-    public void testSimpleStrategy3Xto4() throws Throwable
-    {
-        testSimpleStrategy(Versions.Major.v3X, Versions.Major.v4);
+        testSimpleStrategy(Versions.Major.v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3ReplicationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3ReplicationTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom3ReplicationTest extends MixedModeReplicationTestBase
     @Test
     public void testSimpleStrategy30to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v3X);
+        testSimpleStrategy(v30, v3X);
     }
 
     @Test
     public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30);
+        testSimpleStrategy(v30);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3UnloggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3UnloggedBatchTest.java
@@ -31,14 +31,8 @@ public class MixedModeFrom3UnloggedBatchTest extends MixedModeBatchTestBase
     }
 
     @Test
-    public void testSimpleStrategy30to4() throws Throwable
+    public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v4, false);
-    }
-
-    @Test
-    public void testSimpleStrategy3Xto4() throws Throwable
-    {
-        testSimpleStrategy(Versions.Major.v3X, Versions.Major.v4, false);
+        testSimpleStrategy(Versions.Major.v30, false);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3UnloggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeFrom3UnloggedBatchTest.java
@@ -27,12 +27,12 @@ public class MixedModeFrom3UnloggedBatchTest extends MixedModeBatchTestBase
     @Test
     public void testSimpleStrategy30to3X() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, Versions.Major.v3X, false);
+        testSimpleStrategy(v30, v3X, false);
     }
 
     @Test
     public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(Versions.Major.v30, false);
+        testSimpleStrategy(v30, false);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeGossipTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeGossipTest.java
@@ -50,8 +50,7 @@ public class MixedModeGossipTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(3)
         .nodesToUpgradeOrdered(1, 2, 3)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
-        .upgrade(Versions.Major.v3X, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup(c -> {})
         .runAfterNodeUpgrade((cluster, node) -> {
             if (node == 1) {
@@ -85,8 +84,7 @@ public class MixedModeGossipTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(3)
         .nodesToUpgradeOrdered(1, 2, 3)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
-        .upgrade(Versions.Major.v3X, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup(cluster -> {
             // node2 and node3 gossiper cannot talk with each other
             cluster.filters().verbs(Verb.GOSSIP_DIGEST_SYN.id).from(2).to(3).drop();

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeGossipTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeGossipTest.java
@@ -50,7 +50,7 @@ public class MixedModeGossipTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(3)
         .nodesToUpgradeOrdered(1, 2, 3)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup(c -> {})
         .runAfterNodeUpgrade((cluster, node) -> {
             if (node == 1) {
@@ -84,7 +84,7 @@ public class MixedModeGossipTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(3)
         .nodesToUpgradeOrdered(1, 2, 3)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup(cluster -> {
             // node2 and node3 gossiper cannot talk with each other
             cluster.filters().verbs(Verb.GOSSIP_DIGEST_SYN.id).from(2).to(3).drop();

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
@@ -39,8 +39,7 @@ public class MixedModeReadTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(2)
         .nodesToUpgrade(1)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
-        .upgrade(Versions.Major.v3X, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup(cluster -> {
             cluster.schemaChange(CREATE_TABLE);
             insertData(cluster.coordinator(1));

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
@@ -39,7 +39,7 @@ public class MixedModeReadTest extends UpgradeTestBase
         .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
         .nodes(2)
         .nodesToUpgrade(1)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup(cluster -> {
             cluster.schemaChange(CREATE_TABLE);
             insertData(cluster.coordinator(1));

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeRepairTest.java
@@ -55,8 +55,7 @@ public class MixedModeRepairTest extends UpgradeTestBase
         new UpgradeTestBase.TestCase()
         .nodes(2)
         .nodesToUpgrade(UPGRADED_NODE)
-        .upgrade(Major.v30, Major.v4)
-        .upgrade(Major.v3X, Major.v4)
+        .upgradesFrom(Major.v3X)
         .withConfig(config -> config.with(NETWORK, GOSSIP))
         .setup(cluster -> {
             cluster.schemaChange(CREATE_TABLE);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeRepairTest.java
@@ -35,7 +35,6 @@ import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.fail;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
-import static org.apache.cassandra.distributed.shared.Versions.Major;
 
 public class MixedModeRepairTest extends UpgradeTestBase
 {
@@ -55,7 +54,7 @@ public class MixedModeRepairTest extends UpgradeTestBase
         new UpgradeTestBase.TestCase()
         .nodes(2)
         .nodesToUpgrade(UPGRADED_NODE)
-        .upgradesFrom(Major.v3X)
+        .upgradesFrom(v3X)
         .withConfig(config -> config.with(NETWORK, GOSSIP))
         .setup(cluster -> {
             cluster.schemaChange(CREATE_TABLE);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTestBase.java
@@ -32,6 +32,11 @@ import static org.apache.cassandra.distributed.shared.AssertUtils.row;
  */
 public class MixedModeReplicationTestBase extends UpgradeTestBase
 {
+    protected void testSimpleStrategy(Versions.Major from) throws Throwable
+    {
+        testSimpleStrategy(from, UpgradeTestBase.CURRENT);
+    }
+
     protected void testSimpleStrategy(Versions.Major from, Versions.Major to) throws Throwable
     {
         String insert = "INSERT INTO test_simple.names (key, name) VALUES (?, ?)";
@@ -40,7 +45,7 @@ public class MixedModeReplicationTestBase extends UpgradeTestBase
         new TestCase()
         .nodes(3)
         .nodesToUpgrade(1, 2)
-        .upgrade(from, to)
+        .upgrades(from, to)
         .setup(cluster -> {
             cluster.schemaChange("CREATE KEYSPACE test_simple WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};");
             cluster.schemaChange("CREATE TABLE test_simple.names (key int PRIMARY KEY, name text)");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTestBase.java
@@ -21,8 +21,9 @@ package org.apache.cassandra.distributed.upgrade;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.vdurmont.semver4j.Semver;
+
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
-import org.apache.cassandra.distributed.shared.Versions;
 
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
@@ -32,12 +33,12 @@ import static org.apache.cassandra.distributed.shared.AssertUtils.row;
  */
 public class MixedModeReplicationTestBase extends UpgradeTestBase
 {
-    protected void testSimpleStrategy(Versions.Major from) throws Throwable
+    protected void testSimpleStrategy(Semver from) throws Throwable
     {
         testSimpleStrategy(from, UpgradeTestBase.CURRENT);
     }
 
-    protected void testSimpleStrategy(Versions.Major from, Versions.Major to) throws Throwable
+    protected void testSimpleStrategy(Semver from, Semver to) throws Throwable
     {
         String insert = "INSERT INTO test_simple.names (key, name) VALUES (?, ?)";
         String select = "SELECT * FROM test_simple.names WHERE key = ?";

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/PagingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/PagingTest.java
@@ -48,7 +48,7 @@ public class PagingTest extends UpgradeTestBase
     {
         new UpgradeTestBase.TestCase()
         .nodes(2)
-        .upgrade(Versions.Major.v22, Versions.Major.v30)
+        .upgrades(Versions.Major.v22, Versions.Major.v30)
         .nodesToUpgrade(2)
         .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL))
         .setup((cluster) -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/PagingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/PagingTest.java
@@ -48,7 +48,7 @@ public class PagingTest extends UpgradeTestBase
     {
         new UpgradeTestBase.TestCase()
         .nodes(2)
-        .upgrades(Versions.Major.v22, Versions.Major.v30)
+        .upgrades(v22, v30)
         .nodesToUpgrade(2)
         .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL))
         .setup((cluster) -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/Pre40MessageFilterTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/Pre40MessageFilterTest.java
@@ -35,7 +35,7 @@ public class Pre40MessageFilterTest extends UpgradeTestBase
         .nodes(2)
         .withConfig(configConsumer)
         .nodesToUpgrade(1)
-        .upgrade(Versions.Major.v30, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v30)
         .setup((cluster) -> {
             cluster.filters().outbound().allVerbs().messagesMatching((f,t,m) -> false).drop();
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/Pre40MessageFilterTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/Pre40MessageFilterTest.java
@@ -35,7 +35,7 @@ public class Pre40MessageFilterTest extends UpgradeTestBase
         .nodes(2)
         .withConfig(configConsumer)
         .nodesToUpgrade(1)
-        .upgradesFrom(Versions.Major.v30)
+        .upgradesFrom(v30)
         .setup((cluster) -> {
             cluster.filters().outbound().allVerbs().messagesMatching((f,t,m) -> false).drop();
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/ReadRepairCompactStorageUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/ReadRepairCompactStorageUpgradeTest.java
@@ -35,9 +35,7 @@ public class ReadRepairCompactStorageUpgradeTest extends UpgradeTestBase
     {
         new TestCase()
         .nodes(2)
-        .upgrade(Versions.Major.v22, Versions.Major.v30)
-        .upgrade(Versions.Major.v22, Versions.Major.v3X)
-        .upgrade(Versions.Major.v30, Versions.Major.v3X)
+        .upgrades(Versions.Major.v22, Versions.Major.v3X)
         .setup((cluster) -> cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl" +
                                                               " (pk ascii, b boolean, v blob, PRIMARY KEY (pk))" +
                                                               " WITH COMPACT STORAGE")))

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/ReadRepairCompactStorageUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/ReadRepairCompactStorageUpgradeTest.java
@@ -35,7 +35,7 @@ public class ReadRepairCompactStorageUpgradeTest extends UpgradeTestBase
     {
         new TestCase()
         .nodes(2)
-        .upgrades(Versions.Major.v22, Versions.Major.v3X)
+        .upgrades(v22, v3X)
         .setup((cluster) -> cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl" +
                                                               " (pk ascii, b boolean, v blob, PRIMARY KEY (pk))" +
                                                               " WITH COMPACT STORAGE")))

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
@@ -34,7 +34,7 @@ public class UpgradeTest extends UpgradeTestBase
         .nodes(2)
         .nodesToUpgrade(1)
         .withConfig((cfg) -> cfg.with(Feature.NETWORK, Feature.GOSSIP))
-        .upgrade(Versions.Major.v3X, Versions.Major.v4)
+        .upgradesFrom(Versions.Major.v3X)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
             cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
@@ -34,7 +34,7 @@ public class UpgradeTest extends UpgradeTestBase
         .nodes(2)
         .nodesToUpgrade(1)
         .withConfig((cfg) -> cfg.with(Feature.NETWORK, Feature.GOSSIP))
-        .upgradesFrom(Versions.Major.v3X)
+        .upgradesFrom(v3X)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
             cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTestBase.java
@@ -19,14 +19,14 @@
 package org.apache.cassandra.distributed.upgrade;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
 import org.junit.After;
 import org.junit.BeforeClass;
 
@@ -39,11 +39,13 @@ import org.apache.cassandra.distributed.impl.Instance;
 import org.apache.cassandra.distributed.shared.DistributedTestBase;
 import org.apache.cassandra.distributed.shared.Versions;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.distributed.shared.Versions.Major;
 import static org.apache.cassandra.distributed.shared.Versions.Version;
 import static org.apache.cassandra.distributed.shared.Versions.find;
-import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
+
+
 
 public class UpgradeTestBase extends DistributedTestBase
 {
@@ -76,14 +78,22 @@ public class UpgradeTestBase extends DistributedTestBase
         public void run(UpgradeableCluster cluster, int node) throws Throwable;
     }
 
+    public static final List<Pair<Versions.Major,Versions.Major>> SUPPORTED_UPGRADE_PATHS = ImmutableList.of(
+        Pair.create(Versions.Major.v22, Versions.Major.v30),
+        Pair.create(Versions.Major.v22, Versions.Major.v3X),
+        Pair.create(Versions.Major.v30, Versions.Major.v3X),
+        Pair.create(Versions.Major.v30, Versions.Major.v40),
+        Pair.create(Versions.Major.v3X, Versions.Major.v40));
+
+    public static final Versions.Major CURRENT = SUPPORTED_UPGRADE_PATHS.get(SUPPORTED_UPGRADE_PATHS.size() - 1).right;
+
     public static class TestVersions
     {
         final Version initial;
-        final Version[] upgrade;
+        final Version upgrade;
 
-        public TestVersions(Version initial, Version ... upgrade)
+        public TestVersions(Version initial, Version upgrade)
         {
-            Preconditions.checkArgument(isNotEmpty(upgrade), "TestVersions must be constructed with one or more target upgrade versions.");
             this.initial = initial;
             this.upgrade = upgrade;
         }
@@ -116,16 +126,24 @@ public class UpgradeTestBase extends DistributedTestBase
             return this;
         }
 
-        public TestCase upgrade(Major initial, Major ... upgrade)
+        public TestCase upgradesFrom(Major from)
         {
-            this.upgrade.add(new TestVersions(versions.getLatest(initial),
-                                              Arrays.stream(upgrade)
-                                                    .map(versions::getLatest)
-                                                    .toArray(Version[]::new)));
+            return upgrades(from, CURRENT);
+        }
+
+        public TestCase upgrades(Major from, Major to)
+        {
+            SUPPORTED_UPGRADE_PATHS.stream()
+                .filter(upgradePath -> (upgradePath.left.compareTo(from) >= 0 && upgradePath.right.compareTo(to) <= 0))
+                .forEachOrdered(upgradePath ->
+                {
+                    this.upgrade.add(
+                            new TestVersions(versions.getLatest(upgradePath.left), versions.getLatest(upgradePath.right)));
+                });
             return this;
         }
 
-        public TestCase upgrade(Version initial, Version ... upgrade)
+        public TestCase upgrade(Version initial, Version upgrade)
         {
             this.upgrade.add(new TestVersions(initial, upgrade));
             return this;
@@ -177,18 +195,15 @@ public class UpgradeTestBase extends DistributedTestBase
                 {
                     setup.run(cluster);
 
-                    for (Version version : upgrade.upgrade)
+                    for (int n : nodesToUpgrade)
                     {
-                        for (int n : nodesToUpgrade)
-                        {
-                            cluster.get(n).shutdown().get();
-                            cluster.get(n).setVersion(version);
-                            cluster.get(n).startup();
-                            runAfterNodeUpgrade.run(cluster, n);
-                        }
-
-                        runAfterClusterUpgrade.run(cluster);
+                        cluster.get(n).shutdown().get();
+                        cluster.get(n).setVersion(upgrade.upgrade);
+                        cluster.get(n).startup();
+                        runAfterNodeUpgrade.run(cluster, n);
                     }
+
+                    runAfterClusterUpgrade.run(cluster);
                 }
             }
         }
@@ -216,11 +231,7 @@ public class UpgradeTestBase extends DistributedTestBase
     protected TestCase allUpgrades(int nodes, int... toUpgrade)
     {
         return new TestCase().nodes(nodes)
-                             .upgrade(Versions.Major.v22, Versions.Major.v30)
-                             .upgrade(Versions.Major.v22, Versions.Major.v3X)
-                             .upgrade(Versions.Major.v30, Versions.Major.v3X)
-                             .upgrade(Versions.Major.v30, Versions.Major.v4)
-                             .upgrade(Versions.Major.v3X, Versions.Major.v4)
+                             .upgradesFrom(Versions.Major.v22)
                              .nodesToUpgrade(toUpgrade);
     }
 


### PR DESCRIPTION
Changes required for https://github.com/thelastpickle/cassandra-in-jvm-dtest-api/pull/2

fyi @ifesdjeen 